### PR TITLE
MIAJS-767 - Accept a greater version of the typescript-eslint dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   },
   "peerDependencies": {
     "eslint": ">= 4",
-    "@typescript-eslint/eslint-plugin": "^2.23.0"
+    "@typescript-eslint/eslint-plugin": ">=2.23.0"
   }
 }


### PR DESCRIPTION
* During the angular upgrade task, I migrated to `@typescript-eslint/eslint-plugin": "4.16.1`which doesn't play nicely with this dependency as it requires `^2.23.0`.