### PR TITLE
MIAJS-767 - Disable no-undef

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ module.exports = {
         "@typescript-eslint/explicit-member-accessibility": 0,
         "@typescript-eslint/explicit-function-return-type": [1, { "allowExpressions": true }],
         "no-unused-vars": 0,
+        "no-undef": 0,
         "@typescript-eslint/no-unused-vars": 2
     }
 };


### PR DESCRIPTION
Disable `no-undef` according to recommended typescript eslint rules
https://github.com/typescript-eslint/typescript-eslint/blob/master/docs/getting-started/linting/FAQ.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors